### PR TITLE
fixed bug where extra fields on a different form on the same page could ...

### DIFF
--- a/native-registration.php
+++ b/native-registration.php
@@ -99,7 +99,7 @@ function wpmem_do_wp_register_form()
 
 				default:
 					$input = '<input type="' . $field[3] . '" name="' . $field[2] . '" id="' . $field[2] . '" class="input" value="'; 
-					$input.= ( $_POST ) ? esc_attr( $_POST[ $field[2] ] ) : ''; 
+					$input.= ( isset( $_POST[ $field[2] ] ) ) ? esc_attr( $_POST[ $field[2] ] ) : ''; 
 					$input.= '" size="25" />';
 					break;
 				}


### PR DESCRIPTION
...throw errors after validation

on pages with 2 forms, i.e. login or register, a failed validation on
one form would cause undefined index errors if the other form had any
custom fields.
