### PR TITLE
Use fputcsv for CSV export, makes sure all fields are properly escape…

### DIFF
--- a/admin/user-export.php
+++ b/admin/user-export.php
@@ -3,7 +3,7 @@
  * WP-Members Export Functions
  *
  * Mananges exporting users to a CSV file.
- * 
+ *
  * This file is part of the WP-Members plugin by Chad Butler
  * You can find out more about this plugin at http://rocketgeek.com
  * Copyright (c) 2006-2016  Chad Butler
@@ -27,7 +27,7 @@ function wpmem_export_users( $args, $users = null ) {
 
 	global $wpmem;
 
-	$today = date( "m-d-y" ); 
+	$today = date( "m-d-y" );
 
 	// Setup defaults.
 	$defaults = array(
@@ -44,7 +44,7 @@ function wpmem_export_users( $args, $users = null ) {
 	 * @since 2.9.7
 	 *
 	 * @param array $args An array of arguments to merge with defaults. Default null.
- 	 */
+	 */
 	$args = wp_parse_args( apply_filters( 'wpmem_export_args', $args ), $defaults );
 
 	// Output needs to be buffered, start the buffer.
@@ -58,72 +58,77 @@ function wpmem_export_users( $args, $users = null ) {
 	header( "Content-type: application/octet-stream" );
 	header( "Content-Disposition: attachment; filename=" . $args['filename'] );
 	header( "Content-Type: text/csv; charset=" . get_option( 'blog_charset' ), true );
-	echo "\xEF\xBB\xBF"; // UTF-8 BOM
 
-	// Do the header row.
-	$hrow = "User ID,Username,";
+	$export_fields = array_filter( $args['export_fields'], function ( $field ) use ( $args ) {
+		return !in_array( $field[2], $args['exclude_fields'] );
+	});
 
-	foreach ( $args['export_fields'] as $meta => $field ) {
-		if ( ! in_array( $meta, $args['exclude_fields'] ) ) {
-			$hrow.= $field['label'] . ",";
-		}
+	$handle = fopen( 'php://output', 'w' );
+	fputs( $handle, "\xEF\xBB\xBF" ); // UTF-8 BOM
+
+	$header = [ 'User ID', 'Username' ];
+	array_walk($export_fields, function ( $field ) use ( &$header ) {
+		$header[] = $field[1];
+	});
+
+	if ( $wpmem->mod_reg == 1 ) {
+		$header[] = __( 'Activated?', 'wp-members');
 	}
 
-	$hrow .= ( $wpmem->mod_reg == 1 ) ? __( 'Activated?', 'wp-members' ) . "," : '';
-	$hrow .= ( defined( 'WPMEM_EXP_MODULE' ) && $wpmem->use_exp == 1 ) ? __( 'Subscription', 'wp-members' ) . "," . __( 'Expires', 'wp-members' ) . "," : '';
+	if ( defined( 'WPMEM_EXP_MODULE' ) && $wpmem->use_exp == 1 ) {
+		$header[] = __( 'Subscription', 'wp-members' );
+		$header[] = __( 'Expires', 'wp-members' );
+	}
 
-	$hrow .= __( 'Registered', 'wp-members' ) . ",";
-	$hrow .= __( 'IP', 'wp-members' );
-	$data  = $hrow . "\r\n";
+	$header[] = __( 'Registered', 'wp-members' );
+	$header[] = __( 'IP', 'wp-members' );
 
-	/*
-	 * We used the fields array once,
-	 * rewind so we can use it again.
-	 */
-	reset( $args['export_fields'] );
+	fputcsv( $handle, $header );
 
 	/*
 	 * Loop through the array of users,
-	 * build the data, delimit by commas, wrap fields with double quotes, 
+	 * build the data, delimit by commas, wrap fields with double quotes,
 	 * use \n switch for new line.
 	 */
 	foreach ( $users as $user ) {
 
 		$user_info = get_userdata( $user );
 
-		$data .= '"' . $user_info->ID . '","' . $user_info->user_login . '",';
+		$wp_user_fields = [ 'user_email', 'user_nicename', 'user_url', 'display_name' ];
+		$row = array_map(function ( $field ) use ( $user, $user_info, $wp_user_fields ) {
+			return in_array( $field[2], $wp_user_fields ) ? $user_info->{$field[2]} : get_user_meta( $user, $field[2], true );
+		}, $export_fields);
 
-		$wp_user_fields = array( 'user_email', 'user_nicename', 'user_url', 'display_name' );
-		foreach ( $args['export_fields'] as $meta => $field ) {
-			if ( ! in_array( $meta, $args['exclude_fields'] ) ) {
-				// @todo Research using fputcsv to escape fields for export.
-				if ( in_array( $meta, $wp_user_fields ) ){
-					$data .= '"' . $user_info->{$meta} . '",';	
-				} else {
-					$data .= '"' . get_user_meta( $user, $meta, true ) . '",';
-				}
-			}
+		$row = array_merge(
+			[
+				$user_info->ID,
+				$user_info->user_login,
+			],
+			$row
+		);
+
+		if ( $wpmem->mod_reg == 1 ) {
+			$row[] = get_user_meta( $user, 'active', 1 ) ? __( 'Yes' ) : __( 'No' );
 		}
-		
-		$data .= ( $wpmem->mod_reg == 1 ) ? '"' . ( get_user_meta( $user, 'active', 1 ) ? __( 'Yes' ) : __( 'No' ) ) . '",' : '';
-		$data .= ( defined( 'WPMEM_EXP_MODULE' ) && $wpmem->use_exp == 1 ) ? '"' . get_user_meta( $user, "exp_type", true ) . '",' : '';
-		$data .= ( defined( 'WPMEM_EXP_MODULE' ) && $wpmem->use_exp == 1 ) ? '"' . get_user_meta( $user, "expires", true  ) . '",' : '';
-		
-		$data .= '"' . $user_info->user_registered . '",';
-		$data .= '"' . get_user_meta( $user, "wpmem_reg_ip", true ). '"';
-		$data .= "\r\n";
-		
+
+		if ( defined( 'WPMEM_EXP_MODULE' ) && $wpmem->use_exp == 1 ) {
+			$row[] = get_user_meta( $user, 'exp_type', true );
+			$row[] = get_user_meta( $user, 'expires', true );
+		}
+
+		$row[] = $user_info->user_registered;
+		$row[] = get_user_meta( $user, 'wpmem_reg_ip', true );
+
+		fputcsv( $handle, $row );
+
 		// Update the user record as being exported.
 		if ( 'all' != $args['export'] ){
 			update_user_meta( $user, 'exported', 1 );
 		}
 	}
 
-	// We are done, output the CSV.
-	echo $data; 
-
-	// Clear the buffer.
-	ob_flush();
+	fclose( $handle );
+	print(ob_get_clean());
 
 	exit();
 }


### PR DESCRIPTION
…d, also headers

@butlerblog I had problems with headers not being enclosed in quotes and thus being split when the field labels contained commas. I have, as you suggested in your code, used fputcsv to generate the CSV lines instead of setting them up manually, which takes care of properly quoting the fields.